### PR TITLE
Do not needlessly require the deprecated `sys` module in `test/config.js`.

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var sys = require('sys');
-
 var config = {
   publicKey: process.env.OMISE_PUBLIC_KEY,
   secretKey: process.env.OMISE_SECRET_KEY


### PR DESCRIPTION
`sys` module wasn't used in `test/config.js`. Also, `sys` module is deprecated.

There is an ongoing discussion on removing the `sys` module completely in the next major version: nodejs/node#2405.

If you plan on using `sys` functionality, you should switch to the `util` module.