### PR TITLE
Fix side effect when merge config options

### DIFF
--- a/lib/apiResources.js
+++ b/lib/apiResources.js
@@ -29,7 +29,7 @@ function _nestedPathOptions(opts, pathObj, resource, id, data) {
 }
 
 function _makeOptions(options, path, data) {
-  return _.merge(options, path, {body: data});
+  return _.merge({}, options, path, {body: data});
 }
 
 module.exports.omiseResources = function(config) {


### PR DESCRIPTION
Fix issue https://github.com/omise/omise-node/issues/50
When use lodash _.merge function,
it merges others object to first argument,
and return same object.
If first argument is global in scope
of many requests, It will occur side effect.

Fix by use {} for first arguments of _.merge.
It will create new object for result of merge
every request.
