### PR TITLE
Re-order for reverse charge test.

### DIFF
--- a/test/test_omise_charges.js
+++ b/test/test_omise_charges.js
@@ -52,6 +52,16 @@ describe('Omise', function() {
       });
     });
 
+    it('should be able to reverse a charge', function(done) {
+      testHelper.setupMock('charges_reverse');
+      omise.charges.reverse(chargeId, function(err, resp) {
+        expect(resp.object, 'charge');
+        var reversed = resp.reversed;
+        reversed.should.be.true;
+        done();
+      });
+    });
+
     it('should be able to list charges', function(done) {
       testHelper.setupMock('charges_list');
       omise.charges.list(function(err, resp) {
@@ -105,15 +115,6 @@ describe('Omise', function() {
       });
     });
 
-    it('should be able to reverse a charge', function(done) {
-      testHelper.setupMock('charges_reverse');
-      omise.charges.reverse(chargeId, function(err, resp) {
-        expect(resp.object, 'charge');
-        var reversed = resp.reversed;
-        reversed.should.be.true;
-        done();
-      });
-    });
 
   });
 });


### PR DESCRIPTION
A fix for https://github.com/omise/omise-node/issues/51 issue
Reversable is only for charge that is not captured. So, need to re-order test a bit.