### PR TITLE
Fix jscs issue in test/test_omise_charges.js

### DIFF
--- a/test/test_omise_charges.js
+++ b/test/test_omise_charges.js
@@ -115,6 +115,5 @@ describe('Omise', function() {
       });
     });
 
-
   });
 });


### PR DESCRIPTION
Hi, I fixed the issue that reported by jscs:

```
$ npm run jscs

> omise@0.5.3 jscs /Users/wingyplus/project/me/omise-node
> jscs *.js lib/*.js test/*.js

; and } should have at most 2 line(s) between them at test/test_omise_charges.js :
   114 |        done();
   115 |      });
   116 |    });
---------------^
   117 |
   118 |


1 code style error found.
```