### PR TITLE
Refactor require module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
-// Omise.co
-var resource = require('./lib/apiResources.js');
+//Omise.co
+var resource = require('./lib/apiResources');
 module.exports = function(config) {
   return resource.omiseResources(config);
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -6,7 +6,7 @@ var Promise     = require('bluebird');
 var logger      = require('./logger');
 var pkgjson     = require('../package.json');
 
-var ApiError    = require('./errors/api-error.js');
+var ApiError    = require('./errors/api-error');
 
 function _responseHandler(req) {
   return new Promise(function(resolve, reject) {

--- a/lib/apiResources.js
+++ b/lib/apiResources.js
@@ -4,7 +4,7 @@ var _   = require('lodash');
 var omiseConfig;
 
 function resourceName(name) {
-  return require(['./resources/', name, '.js'].join(''))(omiseConfig);
+  return require(['./resources/', name].join(''))(omiseConfig);
 }
 
 function resourcePath(name) {

--- a/test/test_omise_account.js
+++ b/test/test_omise_account.js
@@ -1,7 +1,7 @@
 var chai   = require('chai');
 var expect = chai.expect;
-var config = require('./config.js');
-var omise  = require('../index')(config);
+var config = require('./config');
+var omise = require('../index')(config);
 var testHelper = require('./testHelper');
 
 describe('Omise', function() {

--- a/test/test_omise_balance.js
+++ b/test/test_omise_balance.js
@@ -1,6 +1,6 @@
 var chai   = require('chai');
 var expect = chai.expect;
-var config = require('./config.js');
+var config = require('./config');
 var omise  = require('../index')(config);
 var testHelper = require('./testHelper');
 

--- a/test/test_omise_cards.js
+++ b/test/test_omise_cards.js
@@ -2,8 +2,8 @@ var chai   = require('chai');
 var expect = chai.expect;
 var should = chai.should();
 
-var config = require('./config.js');
-var omise  = require('../index')(config);
+var config = require('./config');
+var omise = require('../index')(config);
 var testHelper = require('./testHelper');
 
 describe('Omise', function() {

--- a/test/test_omise_charges.js
+++ b/test/test_omise_charges.js
@@ -3,7 +3,7 @@ var chai   = require('chai');
 var expect = chai.expect;
 var should = chai.should();
 
-var config = require('./config.js');
+var config = require('./config');
 var omise  = require('../index')(config);
 var testHelper = require('./testHelper');
 

--- a/test/test_omise_customers.js
+++ b/test/test_omise_customers.js
@@ -3,7 +3,7 @@ var chai   = require('chai');
 var expect = chai.expect;
 var should = chai.should();
 
-var config = require('./config.js');
+var config = require('./config');
 var omise  = require('../index')(config);
 var testHelper = require('./testHelper');
 

--- a/test/test_omise_disputes.js
+++ b/test/test_omise_disputes.js
@@ -1,8 +1,8 @@
 'use strict';
 var chai   = require('chai');
 var expect = chai.expect;
-var config = require('./config.js');
-var omise  = require('../index')(config);
+var config = require('./config');
+var omise = require('../index')(config);
 var testHelper = require('./testHelper');
 
 describe('Omise', function() {

--- a/test/test_omise_events.js
+++ b/test/test_omise_events.js
@@ -1,8 +1,8 @@
 var chai   = require('chai');
 var expect = chai.expect;
 
-var config = require('./config.js');
-var omise  = require('../index')(config);
+var config = require('./config');
+var omise = require('../index')(config);
 var testHelper = require('./testHelper');
 
 describe('Omise', function() {

--- a/test/test_omise_recipients.js
+++ b/test/test_omise_recipients.js
@@ -1,8 +1,8 @@
 'use strict';
 var chai   = require('chai');
 var expect = chai.expect;
-var config = require('./config.js');
-var omise  = require('../index')(config);
+var config = require('./config');
+var omise = require('../index')(config);
 var testHelper = require('./testHelper');
 
 describe('Omise', function() {

--- a/test/test_omise_refunds.js
+++ b/test/test_omise_refunds.js
@@ -2,8 +2,8 @@ var chai   = require('chai');
 var expect = chai.expect;
 var should = chai.should();
 
-var config = require('./config.js');
-var omise  = require('../index')(config);
+var config = require('./config');
+var omise = require('../index')(config);
 var testHelper = require('./testHelper');
 
 describe('Omise', function() {

--- a/test/test_omise_tokens.js
+++ b/test/test_omise_tokens.js
@@ -2,7 +2,7 @@ var chai   = require('chai');
 var expect = chai.expect;
 var should = chai.should();
 
-var config = require('./config.js');
+var config = require('./config');
 var omise  = require('../index')(config);
 var testHelper = require('./testHelper');
 

--- a/test/test_omise_transactions.js
+++ b/test/test_omise_transactions.js
@@ -1,6 +1,6 @@
 var chai   = require('chai');
 var expect = chai.expect;
-var config = require('./config.js');
+var config = require('./config');
 var omise  = require('../index')(config);
 var testHelper = require('./testHelper');
 

--- a/test/test_omise_transfers.js
+++ b/test/test_omise_transfers.js
@@ -1,6 +1,6 @@
 var chai   = require('chai');
 var expect = chai.expect;
-var config = require('./config.js');
+var config = require('./config');
 var omise  = require('../index')(config);
 var testHelper = require('./testHelper');
 


### PR DESCRIPTION
It can be remove '.js' suffix because it require js file by default.