### PR TITLE
Add missing @types/lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/omise/omise-node",
   "dependencies": {
     "@types/bluebird": "^3.5.15",
+    "@types/lodash": "^4.14.77",
     "@types/node": "^8.0.34",
     "bluebird": "^2.9.12",
     "lodash": "^3.2.0"


### PR DESCRIPTION
When try to compile typescript under ./types/example directory,
it's throw an error:

```console
$ ./node_modules/.bin/tsc ./types/examples/as_promises.ts
node_modules/@types/bluebird/index.d.ts(622,33): error TS2304: Cannot find name 'Map'.
node_modules/@types/bluebird/index.d.ts(622,72): error TS2304: Cannot find name 'Map'.
node_modules/@types/bluebird/index.d.ts(822,39): error TS2304: Cannot find name 'Map'.
node_modules/@types/bluebird/index.d.ts(822,78): error TS2304: Cannot find name 'Map'.
node_modules/@types/bluebird/index.d.ts(826,27): error TS2304: Cannot find name 'Map'.
node_modules/@types/bluebird/index.d.ts(826,65): error TS2304: Cannot find name 'Map'.
```

It happen because of missing `@types/lodash` in dependencies block.