### PR TITLE
Fix pre-commit.sh symlink path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ $ npm test
 You could use also use a git pre-commit hook to do this automatically by aliasing the `pre-commit.sh` to Git pre-commit hook:
 
 ```
-ln -s ../../pre-commit.sh .git/hooks/pre-commit
+ln -s ./pre-commit.sh .git/hooks/pre-commit
 ```
 
 ### Adding new resources


### PR DESCRIPTION
I see in the README.md symlink `pre-commit.sh` location to `../../pre-commit.sh`. It's not correct because `pre-commit.sh` live on the root directory of omise-node.

This PR fix the problem I mentioned above.