### PR TITLE
Replace deprecated Buffer constructor

### DIFF
--- a/examples/as_promises.js
+++ b/examples/as_promises.js
@@ -7,21 +7,21 @@ var omise = require('../index')({
 
 var cardDetails = {
   card: {
-    'name': 'JOHN DOE',
-    'city': 'Bangkok',
-    'postal_code': 10320,
-    'number': '4242424242424242',
+    'name':             'JOHN DOE',
+    'city':             'Bangkok',
+    'postal_code':      10320,
+    'number':           '4242424242424242',
     'expiration_month': 2,
-    'expiration_year': 2017,
+    'expiration_year':  2017,
   },
 };
 
 omise.tokens.create(cardDetails).then(function(token) {
   console.log(token);
   return omise.customers.create({
-    'email': 'john.doe@example.com',
+    'email':       'john.doe@example.com',
     'description': 'John Doe (id: 30)',
-    'card': token.id,
+    'card':        token.id,
   });
 }).then(function(customer) {
   console.log(customer);

--- a/examples/create_token.js
+++ b/examples/create_token.js
@@ -7,12 +7,12 @@ var omise = require('../index')({
 
 var cardDetails = {
   card: {
-    'name': 'JOHN DOE',
-    'city': 'Bangkok',
-    'postal_code': 10160,
-    'number': '4532156433142865',
+    'name':             'JOHN DOE',
+    'city':             'Bangkok',
+    'postal_code':      10160,
+    'number':           '4532156433142865',
     'expiration_month': 8,
-    'expiration_year': 2022,
+    'expiration_year':  2022,
   },
 };
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
-//Omise.co
+// Omise.co
 var resource = require('./lib/apiResources');
 module.exports = function(config) {
   return resource.omiseResources(config);

--- a/lib/api.js
+++ b/lib/api.js
@@ -48,7 +48,9 @@ function _buildContentHeaders(options) {
 }
 
 function _authenticate(options) {
-  var base64Encoded = Buffer.from(options['key'] + ':').toString('base64');
+  var key = options['key'] + ':';
+  var buffer = Buffer.from ? Buffer.from(key) : new Buffer(key);
+  var base64Encoded = buffer.toString('base64');
   return {'basic': 'Basic ' + base64Encoded};
 }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -49,7 +49,17 @@ function _buildContentHeaders(options) {
 
 function _authenticate(options) {
   var key = options['key'] + ':';
-  var buffer = Buffer.from ? Buffer.from(key) : new Buffer(key);
+  var buffer;
+
+  try {
+    buffer = Buffer.from(key);
+  } catch (e) {
+    if (e.message === 'this is not a typed array') {
+      buffer = new Buffer(key);
+    } else {
+      throw e;
+    }
+  }
   var base64Encoded = buffer.toString('base64');
   return {'basic': 'Basic ' + base64Encoded};
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -51,15 +51,12 @@ function _authenticate(options) {
   var key = options['key'] + ':';
   var buffer;
 
-  try {
+  if (Buffer.allocUnsafe) {
     buffer = Buffer.from(key);
-  } catch (e) {
-    if (e.message === 'this is not a typed array.') {
-      buffer = new Buffer(key);
-    } else {
-      throw e;
-    }
+  } else {
+    buffer = new Buffer(key);
   }
+
   var base64Encoded = buffer.toString('base64');
   return {'basic': 'Basic ' + base64Encoded};
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -54,7 +54,7 @@ function _authenticate(options) {
   try {
     buffer = Buffer.from(key);
   } catch (e) {
-    if (e.message === 'this is not a typed array') {
+    if (e.message === 'this is not a typed array.') {
       buffer = new Buffer(key);
     } else {
       throw e;

--- a/lib/api.js
+++ b/lib/api.js
@@ -48,7 +48,7 @@ function _buildContentHeaders(options) {
 }
 
 function _authenticate(options) {
-  var base64Encoded = new Buffer(options['key'] + ':').toString('base64');
+  var base64Encoded = Buffer.from(options['key'] + ':').toString('base64');
   return {'basic': 'Basic ' + base64Encoded};
 }
 


### PR DESCRIPTION
`Buffer` constructor has been deprecated because of security reasons and has been replaced with `Buffer.from`

https://nodesource.com/blog/understanding-the-buffer-deprecation-in-node-js-10/

