### PR TITLE
[Issue #103] Ensure that failed HTTP request doesn't ruined server

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -31,7 +31,8 @@ function _responseHandler(req) {
           reject(err);
         }
       });
-    });
+    })
+      .on('error', reject);
   });
 }
 

--- a/test/test_omise_balance.js
+++ b/test/test_omise_balance.js
@@ -3,9 +3,27 @@ var expect = chai.expect;
 var config = require('./config');
 var omise  = require('../index')(config);
 var testHelper = require('./testHelper');
+var nock = require('nock');
 
 describe('Omise', function() {
   describe('#Balance', function() {
+    it('should not raise exception connection to Omise is failed', function(done) {
+      nock('"https://api.omise.co')
+        .get('/balance')
+        .reply(1001, 'DNS resolution error');
+      try {
+        omise.balance.retrieve(function(err) {
+          if (err) {
+            done();
+          } else {
+            done('Server is wrecked');
+          }
+        });
+      } catch (err) {
+        done(err);
+      }
+    });
+
     it('should be able to retrieve a balance', function(done) {
       testHelper.setupMock('balance_retrieve');
       omise.balance.retrieve(function(err, resp) {


### PR DESCRIPTION
Issue: #103 
Handle failed HTTP request by rejecting instead of letting the exception bubbled up.

