### PR TITLE
Add a support for Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ The following API methods are available. Please see [https://www.omise.co/docs](
   * `create(data)`
   * `destroy(scheduleId)`
   * `retrieve([scheduleId])`
+* search
+  * `list(data)`
 
 ## Testing
 

--- a/lib/apiResources.js
+++ b/lib/apiResources.js
@@ -50,6 +50,7 @@ module.exports.omiseResources = function(config) {
     links:        resourceName('Link'),
     account:      resourceName('Account'),
     balance:      resourceName('Balance'),
+    search:       resourceName('Search'),
   };
 };
 

--- a/lib/resources/Search.js
+++ b/lib/resources/Search.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var resource = require('../apiResources');
+
+var searches = function (config) {
+  return resource.resourceActions('search', ['list'],
+    { 'key': config['secretKey'], 'omiseVersion': config['omiseVersion'] }
+  );
+};
+
+module.exports = searches;

--- a/lib/resources/Search.js
+++ b/lib/resources/Search.js
@@ -2,9 +2,9 @@
 
 var resource = require('../apiResources');
 
-var searches = function (config) {
+var searches = function(config) {
   return resource.resourceActions('search', ['list'],
-    { 'key': config['secretKey'], 'omiseVersion': config['omiseVersion'] }
+    {'key': config['secretKey'], 'omiseVersion': config['omiseVersion']}
   );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "omise",
-  "version": "0.5.6",
+  "version": "0.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/mocks/search_transfer.js
+++ b/test/mocks/search_transfer.js
@@ -1,0 +1,54 @@
+var nock = require('nock');
+
+
+var url = '/search';
+nock('https://api.omise.co')
+  .persist()
+  .get(url)
+  .reply(200, {
+    'object':      'search',
+    'order':       'reverse_chronological',
+    'scope':       'transfer',
+    'export':      null,
+    'query':       '',
+    'filters':     {},
+    'page':        1,
+    'per_page':    1,
+    'location':    '/search',
+    'total_pages': 2,
+    'total':       2,
+    'data':        [
+      {
+        'object':       'transfer',
+        'id':           'trsf_test_no1t4tnemucod0e51mo',
+        'livemode':     false,
+        'location':     '/transfers/trsf_test_no1t4tnemucod0e51mo',
+        'recipient':    'recp_test_no1t4tnemucod0e51mo',
+        'bank_account': {
+          'object':      'bank_account',
+          'brand':       'test',
+          'last_digits': '6789',
+          'name':        'DEFAULT BANK ACCOUNT',
+          'created':     '2019-12-31T12:59:59Z',
+        },
+        'sent':            false,
+        'paid':            false,
+        'amount':          47448,
+        'currency':        'thb',
+        'fee':             3000,
+        'sendable':        true,
+        'fail_fast':       false,
+        'failure_code':    null,
+        'failure_message': null,
+        'transaction':     null,
+        'schedule':        null,
+        'created':         '2019-12-31T12:59:59Z',
+        'sent_at':         null,
+        'paid_at':         null,
+        'metadata':        {},
+      },
+    ],
+  }, {
+    'server':       'nginx/1.1',
+    'content-type': 'application/json',
+  });

--- a/test/test_omise_search.js
+++ b/test/test_omise_search.js
@@ -1,0 +1,19 @@
+var chai = require('chai');
+var expect = chai.expect;
+var config = require('./config');
+var omise = require('../index')(config);
+var testHelper = require('./testHelper');
+
+describe('Omise', function() {
+  describe('#Search', function() {
+    it('should be able to search a transfer scope', function(done) {
+      testHelper.setupMock('search_transfer');
+      var data = {'scope': 'transfer'};
+      omise.search.list(data, function(err, resp) {
+        expect(resp.object, 'search');
+        expect(resp.scope, 'transfer');
+        done(err);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Usage example:
```
const result = await omise.search.list({
    scope: "charge",
    filters: {
      created: "2019-11-01..2019-11-30"
    }
  });
```