### PR TITLE
Enable to give `omiseVersion` option in constructor in TypeScript

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,6 +13,7 @@ declare namespace Omise {
   export interface IOptions {
     publicKey: string;
     secretKey: string;
+    omiseVersion?: string;
   }
 
   export interface IOmise {


### PR DESCRIPTION
Add `omiseVersion?` in IOptions type.

This change enables to write as follow in TypeScript.

```ts
import * as Omise from 'omise';

const omise = Omise({
  publicKey: OMISE_CONFIG.PUBLIC_KEY,
  secretKey: OMISE_CONFIG.SECRET_KEY,
  omiseVersion: '2019-05-29'
});
```