### PR TITLE
Fix typo: 'account' instead of 'accounts'

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ declare namespace Omise {
   }
 
   export interface IOmise {
-    accounts: Account.IAccountAPI;
+    account: Account.IAccountAPI;
     balances: Balance.IBalanceAPI;
     charges: Charges.IChargesAPI;
     customers: Customers.ICustomersAPI;


### PR DESCRIPTION
#### 1. Objective

Fix for issue #125 
IDE suggests a wrong attribute

#### 2. Description of change

Renamed in typescript type information file `index.d.ts` element responsible for `account`

#### 3. Quality assurance

- Install omise node library in your project using command `npm i git:github.com/omise/omise-node.git#fix-typo`
- check if in visual studio correct hint is displayed when using omise library ![image](https://user-images.githubusercontent.com/10651523/82010910-a7f36700-969d-11ea-8681-134089c370c0.png)


#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A