### PR TITLE
Add support of capability api

### DIFF
--- a/lib/apiResources.js
+++ b/lib/apiResources.js
@@ -51,6 +51,7 @@ module.exports.omiseResources = function(config) {
     account:      resourceName('Account'),
     balance:      resourceName('Balance'),
     search:       resourceName('Search'),
+    capability:   resourceName('Capability'),
   };
 };
 

--- a/lib/resources/Capability.js
+++ b/lib/resources/Capability.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var resource = require('../apiResources');
+
+var capability = function(config) {
+  return resource.resourceActions('capability',
+    ['retrieve'],
+    {
+      'key':          config['publicKey'],
+      'omiseVersion': config['omiseVersion'],
+    }
+  );
+};
+
+module.exports = capability;

--- a/test/mocks/capability_retrieve.js
+++ b/test/mocks/capability_retrieve.js
@@ -1,0 +1,161 @@
+var nock = require('nock');
+nock('https://api.omise.co')
+  .persist()
+  .get('/capability')
+  .reply(200, {
+      object: 'capability',
+      location: '/capability',
+      banks:
+        ['test',
+          'bbl',
+          'kbank',
+          'rbs',
+          'ktb',
+          'jpm',
+          'mufg',
+          'tmb',
+          'scb',
+          'citi',
+          'smbc',
+          'sc',
+          'cimb',
+          'uob',
+          'bay',
+          'mega',
+          'boa',
+          'cacib',
+          'gsb',
+          'hsbc',
+          'db',
+          'ghb',
+          'baac',
+          'mb',
+          'bnp',
+          'tbank',
+          'ibank',
+          'tisco',
+          'kk',
+          'icbc',
+          'tcrb',
+          'lhb'],
+      payment_methods:
+        [{
+          object: 'payment_method',
+          name: 'card',
+          currencies: [Array],
+          card_brands: [Array],
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'internet_banking_bay',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'internet_banking_ktb',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'internet_banking_scb',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'internet_banking_bbl',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'alipay',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'installment_bay',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: [Array]
+        },
+        {
+          object: 'payment_method',
+          name: 'installment_kbank',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: [Array]
+        },
+        {
+          object: 'payment_method',
+          name: 'installment_ktc',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: [Array]
+        },
+        {
+          object: 'payment_method',
+          name: 'installment_bbl',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: [Array]
+        },
+        {
+          object: 'payment_method',
+          name: 'installment_first_choice',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: [Array]
+        },
+        {
+          object: 'payment_method',
+          name: 'bill_payment_tesco_lotus',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'barcode_alipay',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'promptpay',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'truemoney',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        },
+        {
+          object: 'payment_method',
+          name: 'points_citi',
+          currencies: [Array],
+          card_brands: null,
+          installment_terms: null
+        }],
+      country: 'TH',
+      zero_interest_installments: true
+    }, {
+    'server': 'nginx/1.1',
+    'content-type': 'application/json',
+  });
+
+

--- a/test/test_omise_capability.js
+++ b/test/test_omise_capability.js
@@ -1,0 +1,19 @@
+var chai   = require('chai');
+var expect = chai.expect;
+var config = require('./config');
+var omise = require('../index')(config);
+var testHelper = require('./testHelper');
+
+describe('Omise', function() {
+  describe('#Capabilities', function() {
+    it('should be able to retrieve information about capabilities', function(done) {
+      testHelper.setupMock('capability_retrieve');
+      omise.capability.retrieve(function(err, resp) {
+        expect(resp.object, 'capability');
+        expect(resp.banks).to.be.an('array');
+        expect(resp.zero_interest_installments).to.be.a('boolean')
+        done(err);
+      });
+    });
+  });
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,6 +19,7 @@ declare namespace Omise {
   export interface IOmise {
     accounts: Account.IAccountAPI;
     balances: Balance.IBalanceAPI;
+    capabilities: Capability.ICapabilityAPI;
     charges: Charges.IChargesAPI;
     customers: Customers.ICustomersAPI;
     disputes: Disputes.IDisputesAPI;
@@ -54,6 +55,19 @@ declare namespace Omise {
       available: number;
       total: number;
       currency: string;
+    }
+  }
+
+  export namespace Capability {
+    interface ICapabilityAPI {
+      retrieve(callback?: ResponseCallback<ICapability>): Bluebird<ICapability>;
+    }
+
+    interface ICapability extends IBaseResponse {
+      banks: string[];
+      payment_methods: any[];
+      country: string;
+      zero_interest_installments: boolean;
     }
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,7 +19,7 @@ declare namespace Omise {
   export interface IOmise {
     accounts: Account.IAccountAPI;
     balances: Balance.IBalanceAPI;
-    capabilities: Capability.ICapabilityAPI;
+    capability: Capability.ICapabilityAPI;
     charges: Charges.IChargesAPI;
     customers: Customers.ICustomersAPI;
     disputes: Disputes.IDisputesAPI;


### PR DESCRIPTION
#### 1. Objective

Add support of `capability API`

#### 2. Description of change

- added new resource responsible for capability API call.
- updated `index.d.ts`
- added automatic tests

#### 3. Quality assurance

Install `omise-node` library in your project using `NPM` command `npm i git:github.com/omise/omise-node.git#capability-api`

retrieve capabilities using the following code example:

```
const omise = require('omise')({
    publicKey: 'pkey_test_XXXXXX',
    secretKey: 'skey_test_XXXXXX',
    omiseVersion: '2019-05-29'
  });
 omise.capability.retrieve(function(err, capability) {
    console.log(capability);
  });
```
check if capabilities are properly displayed.

or use auto-tests - run `npm test`

#### 4. Impact of the change

N/A

#### 5. Priority of change

Normal

#### 6. Additional Notes

N/A