### PR TITLE
Support expire a charge

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The following API methods are available. Please see [https://www.omise.co/docs](
   * `createRefund(chargeId[, data])`
   * `update(chargeId[, data])`
   * `reverse(chargeId)`
+  * `expire(chargeId)`
   * `schedules([data])`
 * customers
   * `create(data)`

--- a/lib/apiResources.js
+++ b/lib/apiResources.js
@@ -119,6 +119,10 @@ module.exports.resourceActions = function (name, actions, options) {
       return api.post(_nestedPathOptions(options, path(resourceId), 'reverse'),
         callback);
     },
+    expire: function (resourceId, callback) {
+      return api.post(_nestedPathOptions(options, path(resourceId), 'expire'),
+        callback);
+    },
 
     // Card
     listCards: function (resourceId, data, callback) {

--- a/lib/resources/Charge.js
+++ b/lib/resources/Charge.js
@@ -5,7 +5,7 @@ var resource = require('../apiResources');
 var charges = function(config) {
   return resource.resourceActions('charges',
     ['create', 'list', 'retrieve', 'update',
-      'capture', 'reverse', 'createRefund', 'listRefunds', 'retrieveRefund',
+      'capture', 'reverse', 'expire', 'createRefund', 'listRefunds', 'retrieveRefund',
       'schedules',
     ],
     {'key': config['secretKey'], 'omiseVersion': config['omiseVersion']}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "omise",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1076,9 +1076,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "log-symbols": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^8.10.60",
     "bluebird": "^2.9.12",
     "https-proxy-agent": "^2.2.4",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.19"
   },
   "devDependencies": {
     "chai": "^2.0.0",

--- a/test/mocks/charge_expire.js
+++ b/test/mocks/charge_expire.js
@@ -1,0 +1,114 @@
+var nock = require('nock');
+
+var chargeID   = 'chrg_test_4z429hvnv7ouolu6kmp';
+
+nock('https://api.omise.co')
+  .persist()
+  .post('/charges/' + chargeID + '/expire')
+  .reply(200, {
+    'object': 'charge',
+    'id': chargeID,
+    'location': '/charges/' + chargeID,
+    'amount': 500000,
+    'net': 491172,
+    'fee': 8250,
+    'fee_vat': 578,
+    'interest': 0,
+    'interest_vat': 0,
+    'funding_amount': 500000,
+    'refunded_amount': 0,
+    'authorized': false,
+    'capturable': false,
+    'capture': true,
+    'disputable': false,
+    'livemode': false,
+    'refundable': false,
+    'reversed': false,
+    'reversible': false,
+    'voided': false,
+    'paid': false,
+    'expired': true,
+    'platform_fee': {
+      'fixed': null,
+      'amount': null,
+      'percentage': null
+    },
+    'currency': 'THB',
+    'funding_currency': 'THB',
+    'ip': null,
+    'refunds': {
+      'object': 'list',
+      'data': [
+
+      ],
+      'limit': 20,
+      'offset': 0,
+      'total': 0,
+      'location': '/charges/' + chargeID + '/refunds',
+      'order': 'chronological',
+      'from': '1970-01-01T00:00:00Z',
+      'to': '2020-07-17T23:48:38Z'
+    },
+    'link': null,
+    'description': null,
+    'metadata': {
+    },
+    'card': null,
+    'source': {
+      'object': 'source',
+      'id': 'src_test_5kkoqejpb1d7x12hi2u',
+      'livemode': false,
+      'location': '/sources/src_test_5kkoqejpb1d7x12hi2u',
+      'amount': 500000,
+      'barcode': '281234567890123456',
+      'created_at': '2020-07-17T23:48:15Z',
+      'currency': 'THB',
+      'email': null,
+      'flow': 'offline',
+      'installment_term': null,
+      'name': null,
+      'mobile_number': null,
+      'phone_number': null,
+      'scannable_code': null,
+      'references': {
+        'expires_at': '2020-07-18T23:48:15Z',
+        'device_id': null,
+        'customer_amount': null,
+        'customer_currency': null,
+        'customer_exchange_rate': null,
+        'omise_tax_id': null,
+        'reference_number_1': null,
+        'reference_number_2': null,
+        'barcode': null,
+        'payment_code': null,
+        'va_code': null
+      },
+      'store_id': null,
+      'store_name': null,
+      'terminal_id': null,
+      'type': 'barcode_alipay',
+      'zero_interest_installments': null,
+      'charge_status': 'expired'
+    },
+    'schedule': null,
+    'customer': null,
+    'dispute': null,
+    'transaction': null,
+    'failure_code': null,
+    'failure_message': null,
+    'status': 'expired',
+    'authorize_uri': null,
+    'return_uri': null,
+    'created_at': '2020-07-17T23:48:15Z',
+    'paid_at': null,
+    'expires_at': '2020-07-17T23:48:38Z',
+    'expired_at': '2020-07-17T23:48:38Z',
+    'reversed_at': null,
+    'zero_interest_installments': true,
+    'branch': null,
+    'terminal': null,
+    'device': null
+  }, {
+    'server':       'nginx/1.1',
+    'content-type': 'application/json',
+  });

--- a/test/test_omise_charges.js
+++ b/test/test_omise_charges.js
@@ -64,6 +64,15 @@ describe('Omise', function() {
       });
     });
 
+    it('should be able to expire a charge', function(done) {
+      testHelper.setupMock('charge_expire');
+      omise.charges.expire(chargeId, function(err, resp) {
+        expect(resp.object, 'charge');
+        expect(resp.expired).be.true;
+        done(err);
+      });
+    });
+
     it('should be able to list charges', function(done) {
       testHelper.setupMock('charges_list');
       omise.charges.list(function(err, resp) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -118,6 +118,7 @@ declare namespace Omise {
       list(parameters?: Pagination.IRequest, callback?: ResponseCallback<IChargeList>): Bluebird<IChargeList>;
       capture(chargeID: string, callback?: ResponseCallback<ICharge>): Bluebird<ICharge>;
       reverse(chargeID: string, callback?: ResponseCallback<ICharge>): Bluebird<ICharge>;
+      expire(chargeID: string, callback?: ResponseCallback<ICharge>): Bluebird<ICharge>;
       createRefund(chargeID: string, callback?: ResponseCallback<IRefundResponse>): Bluebird<IRefundResponse>;
       listRefunds(chargeID: string, callback?: ResponseCallback<IListRefundResponse>): Bluebird<IListRefundResponse>;
       retrieveRefund(chargeID: string, refundID: string, callback?: ResponseCallback<IRefundResponse>): Bluebird<IRefundResponse>;


### PR DESCRIPTION
### 1. Objective

Add support of account API

### 2. Description of change

- added new resource responsible for a charge expire call.
- updated index.d.ts
- added automatic tests

### 3. Quality assurance
Expire a charge
```
const omise = require('omise')({
    publicKey: 'pkey_test_XXXXXX',
    secretKey: 'skey_test_XXXXXX',
    omiseVersion: '2019-05-29'
  });
 omise.charge.expire(charge_id, function(err, charge) {
    console.log(charge.expired); // should be true
  });
```
check if account are updated.

or use auto-tests - run `npm test`

### 4. Impact of the change

N/A

### 5. Priority of change

Normal

### 6. Additional Notes

N/A