### PR TITLE
[Fix] Authentication for customer schedules

### DIFF
--- a/lib/apiResources.js
+++ b/lib/apiResources.js
@@ -105,8 +105,7 @@ module.exports.resourceActions = function (name, actions, options) {
           data);
         return api.get(pathOptions, callback);
       } else {
-        var options = _makeOptions(options, path('schedules'), data);
-        return api.get(options, callback);
+        return api.get(_makeOptions(options, path('schedules'), data), callback);
       }
     },
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -223,6 +223,8 @@ declare namespace Omise {
       updateCard(customerID: string, cardID: string, details: Cards.ICardRequest,
         callback?: ResponseCallback<Cards.ICard>): Bluebird<Cards.ICard>;
       destroyCard(customerID: string, cardID: string, callback?: ResponseCallback<Cards.ICard>): Bluebird<Cards.ICard>;
+      schedules(customerID: string, callback?: ResponseCallback<Schedules.ISchedulesList>)
+        : Bluebird<Schedules.ISchedulesList>;
     }
 
     interface IRequest {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -496,12 +496,12 @@ declare namespace Omise {
       period: string;
       on: Ion;
       in_words: string;
-      start_on: string;
-      end_on: string;
+      start_date: string;
+      end_date: string;
       occurrences: IOccurrences;
-      next_occurrences_on: string[];
+      next_occurrence_dates: string[];
       charge?: ICharge;
-      created_at: string;
+      created: string;
       ended_at: string;
       deleted: boolean; 
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -489,15 +489,23 @@ declare namespace Omise {
 
     interface ISchedule extends IBaseResponse {
       status: string;
+      active: boolean;
       every: number;
       period: string;
       on: Ion;
       in_words: string;
-      start_date: string;
-      end_date: string;
+      start_on: string;
+      end_on: string;
       occurrences: IOccurrences;
-      next_occurrence_dates: string[];
+      next_occurrences_on: string[];
       charge?: ICharge;
+      created_at: string;
+      ended_at: string;
+      deleted: boolean; 
+    }
+
+    interface ISchedulesList extends IOccurrences {
+      data: ISchedule[];
     }
   }
 


### PR DESCRIPTION
## Overview
* First commit fixes an issue with authentication when trying to get a list of schedules for a customer 
* Later commits add missing TS types for customer and schedules.

### What was the authentication issue?
* Authentication error returned when trying to get schedules for a customer using `omise.customers.schedules(customerID)`
* This happened because in `apiResources.js`, the `resourceActions` function was taking an `options` argument (which includes private key), but further down in the `schedules` method, a new variable called options was be declared as `var options = `. This variable was hoisted and therefore leaving `options` as `undefined`
* Fixed by remove duplicate options variable, and instead passing `_makeOptions()` as an argument directly which is consistent with the rest of the file
