### PR TITLE
[ENGA3-907] : change secureProtocol to scheme

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -111,7 +111,7 @@ function _httpsRequest(method, options, callback) {
   var requestOptions = _prepareOptionsFor(method, options);
   logger.log('info', 'request options: ' + JSON.stringify(requestOptions));
 
-  const protocol = process.env.OMISE_SECURE_PROTOCOL || options['secureProtocol'] || 'https';
+  const protocol = process.env.OMISE_SCHEME || options['scheme'] || 'https';
   const request = protocol == 'http' 
     ? http.request(requestOptions) 
     : https.request(requestOptions);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@ declare namespace Omise {
     publicKey: string;
     secretKey: string;
     omiseVersion?: string;
-    secureProtocol?: Scheme;
+    scheme?: Scheme;
     userAgent?: string;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,11 +17,11 @@ declare namespace Omise {
     publicKey: string;
     secretKey: string;
     omiseVersion?: string;
-    secureProtocol?: SecureProtocol;
+    secureProtocol?: Scheme;
     userAgent?: string;
   }
 
-  export enum SecureProtocol {
+  export enum Scheme {
     Http = 'http',
     Https = 'https'
   }


### PR DESCRIPTION
## Purpose
Change `secureProtocol` to `scheme`

[ENGA3-907](https://opn-ooo.atlassian.net/browse/ENGA3-907)

## Description
```
var config = {
    host: 'api.core.svc',
    ...

    scheme: 'http'
};
```
