### PR TITLE
Backward compatibility for handling promise

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,6 +55,8 @@
     ],
     "no-console": "warn",
     "require-jsdoc": "off",
+    "no-invalid-this" : "off",
+    "no-extend-native" : "off",
     "key-spacing": [
       "warn",
       {

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ omise.tokens.retrieve('tokn_test_4xs9408a642a1htto8z', function(error, token) {
 
   // This function will be called after a charge is created.
 
-}).then(function(err) {
+}).catch(function(err) {
 
   // Put error handling code here.
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -161,7 +161,6 @@ function _isValidJsonString(json) {
   return true;
 }
 
-/** added for backward compatibility */
 function handleDeprecatedError(callback) {
   console.warn('The .error() method is deprecated. Please use .catch() instead.'); // eslint-disable-line
   return this.catch(callback);

--- a/lib/api.js
+++ b/lib/api.js
@@ -161,6 +161,20 @@ function _isValidJsonString(json) {
   return true;
 }
 
+/** added for backward compatibility */
+function handleDeprecatedError(callback) {
+  console.warn('The .error() method is deprecated. Please use .catch() instead.'); // eslint-disable-line
+  return this.catch(callback);
+}
+
+function handleDeprecatedDone(callback) {
+  console.warn('The .done() method is deprecated. Please use .finally() instead.'); // eslint-disable-line
+  return this.finally(callback);
+}
+
+Promise.prototype.error = handleDeprecatedError;
+Promise.prototype.done = handleDeprecatedDone;
+
 module.exports = {
   post:    _httpRequestFactory('post'),
   get:     _httpRequestFactory('get'),

--- a/test/test_omise_account.js
+++ b/test/test_omise_account.js
@@ -1,5 +1,4 @@
-const chai = require('chai');
-const expect = chai.expect;
+const {assert} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -9,10 +8,11 @@ describe('Omise', function() {
     it('should be able to retrieve an account', function(done) {
       testHelper.setupMock('account_retrieve');
       omise.account.retrieve(function(err, resp) {
-        expect(resp.object, 'account');
-        expect(resp.id, 'acct_123');
-        expect(resp.email, 'test@omise.co');
-        done(err);
+        if (err) done(err);
+        assert.equal(resp.object, 'account');
+        assert.equal(resp.id, 'acct_123');
+        assert.equal(resp.email, 'test@omise.co');
+        done();
       });
     });
 
@@ -21,12 +21,13 @@ describe('Omise', function() {
       omise.account.updateAccount({
         'webhook_uri': 'https://omise-flask-example.herokuapp.com/webhook',
       }, function(err, resp) {
-        expect(resp.object, 'account');
-        expect(resp.id, 'acct_123');
-        expect(resp.email, 'test@omise.co');
-        expect(resp.webhook_uri,
+        if (err) done(err);
+        assert.equal(resp.object, 'account');
+        assert.equal(resp.id, 'acct_123');
+        assert.equal(resp.email, 'test@omise.co');
+        assert.equal(resp.webhook_uri,
           'https://omise-flask-example.herokuapp.com/webhook');
-        done(err);
+        done();
       });
     });
   });

--- a/test/test_omise_account_promise.js
+++ b/test/test_omise_account_promise.js
@@ -4,7 +4,7 @@ const omise = require('../index')(config);
 const testHelper = require('./testHelper');
 
 describe('Omise', function() {
-  describe('#Promises', function() {
+  describe('#Account', function() {
     it('should be able to retrieve an account using async await', async () => {
       testHelper.setupMock('account_retrieve');
       let resp = await omise.account.retrieve();

--- a/test/test_omise_account_promise.js
+++ b/test/test_omise_account_promise.js
@@ -1,26 +1,40 @@
-const chai = require('chai');
-const expect = chai.expect;
+const {assert} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
 
 describe('Omise', function() {
-  describe('#Account', function() {
+  describe('#Promises', function() {
     it('should be able to retrieve an account using async await', async () => {
       testHelper.setupMock('account_retrieve');
       let resp = await omise.account.retrieve();
-      expect(resp.object, 'account');
-      expect(resp.id, 'acct_123');
-      expect(resp.email, 'test@omise.co');
+      assert.equal(resp.object, 'account');
+      assert.equal(resp.id, 'acct_123');
+      assert.equal(resp.email, 'test@omise.co');
     });
 
     it('should be able to retrieve an account using .then', async () => {
       testHelper.setupMock('account_retrieve');
       omise.account.retrieve().then((resp) => {
-        expect(resp.object, 'account');
-        expect(resp.id, 'acct_123');
-        expect(resp.email, 'test@omise.co');
+        assert.equal(resp.object, 'account');
+        assert.equal(resp.id, 'acct_123');
+        assert.equal(resp.email, 'test@omise.co');
       });
+    });
+
+    it('should be able to use promise with and .done() .error()', (done) => {
+      testHelper.setupMock('account_retrieve');
+      omise.account.retrieve()
+        .then((resp) => {
+          assert.equal(resp.object, 'account');
+          assert.equal(resp.id, 'acct_123');
+          assert.equal(resp.email, 'test@omise.co');
+          done();
+        })
+        .error((err) => {
+          done(err);
+        })
+        .done();
     });
   });
 });

--- a/test/test_omise_api_resource.js
+++ b/test/test_omise_api_resource.js
@@ -1,5 +1,4 @@
-const chai = require('chai');
-const expect = chai.expect;
+const {expect} = require('chai');
 const resource = require('../lib/apiResources');
 
 describe('Api Resource', function() {

--- a/test/test_omise_balance.js
+++ b/test/test_omise_balance.js
@@ -1,5 +1,4 @@
-const chai   = require('chai');
-const expect = chai.expect;
+const {expect, assert} = require('chai');
 const config = require('./config');
 const omise  = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -28,11 +27,12 @@ describe('Omise', function() {
     it('should be able to retrieve a balance', function(done) {
       testHelper.setupMock('balance_retrieve');
       omise.balance.retrieve(function(err, resp) {
-        expect(resp.object, 'balance');
+        if (err) done(err);
+        assert.equal(resp.object, 'balance');
         expect(resp.available).not.be.null;
         expect(resp.total).not.be.null;
-        expect(resp.currency, 'thb');
-        done(err);
+        assert.equal(resp.currency, 'thb');
+        done();
       });
     });
   });

--- a/test/test_omise_capability.js
+++ b/test/test_omise_capability.js
@@ -1,5 +1,4 @@
-const chai   = require('chai');
-const expect = chai.expect;
+const {expect} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -10,10 +9,11 @@ describe('Omise', function() {
       function(done) {
         testHelper.setupMock('capability_retrieve');
         omise.capability.retrieve(function(err, resp) {
+          if (err) done(err);
           expect(resp.object, 'capability');
           expect(resp.banks).to.be.an('array');
           expect(resp.zero_interest_installments).to.be.a('boolean');
-          done(err);
+          done();
         });
       });
   });

--- a/test/test_omise_cards.js
+++ b/test/test_omise_cards.js
@@ -1,7 +1,4 @@
-const chai   = require('chai');
-const expect = chai.expect;
-const should = chai.should();
-
+const {expect, assert, should} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -26,13 +23,14 @@ describe('Omise', function() {
         },
       };
       omise.tokens.create(cardDetails, function(err, resp) {
-        should.exist(resp.id);
+        if (err) done(err);
+        should().exist(resp.id);
         tokenId = resp.id;
         expect(tokenId).to.contains('tokn_test');
-        should.exist(resp.card.id);
+        should().exist(resp.card.id);
         const cardId = resp.card.id;
         expect(cardId).to.contains('card_test');
-        done(err);
+        done();
       });
     });
 
@@ -44,34 +42,37 @@ describe('Omise', function() {
         card:        tokenId,
       };
       omise.customers.create(data, function(err, resp) {
+        if (err) done(err);
         customerId = resp.id;
         expect(customerId).to.contains('cust_test');
         const obj = resp.object;
         obj.should.equal('customer');
         const email = resp.email;
         email.should.equal('john.doe@example.com');
-        done(err);
+        done();
       });
     });
 
     it('should be able to list all cards', function(done) {
       testHelper.setupMock('cards_list');
       omise.customers.listCards(customerId, function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp.data).to.be.instanceof(Array);
-        expect(resp.data[0].object, 'card');
+        assert.equal(resp.data[0].object, 'card');
         cardId = resp.data[0].id;
-        done(err);
+        done();
       });
     });
 
     it('should be able to retrieve a card', function(done) {
       testHelper.setupMock('card_retrieve');
       omise.customers.retrieveCard(customerId, cardId, function(err, resp) {
-        expect(resp.object, 'card');
+        if (err) done(err);
+        assert.equal(resp.object, 'card');
         expect(resp.id).to.match(/^card_test/);
-        expect(resp.brand, 'Visa');
-        done(err);
+        assert.equal(resp.brand, 'Visa');
+        done();
       });
     });
 
@@ -79,20 +80,22 @@ describe('Omise', function() {
       testHelper.setupMock('card_update');
       const data = {'expiration_year': 2022};
       omise.customers.updateCard(customerId, cardId, data, function(err, resp) {
-        expect(resp.object, 'card');
-        expect(resp.id, 'card_test_4z2owrdmvbygi7ah0fu');
-        expect(resp.brand, 'Visa');
-        done(err);
+        if (err) done(err);
+        assert.equal(resp.object, 'card');
+        assert.equal(resp.id, 'card_test_4z2owrdmvbygi7ah0fu');
+        assert.equal(resp.brand, 'Visa');
+        done();
       });
     });
 
     it('should be able to destroy a card', function(done) {
       testHelper.setupMock('card_destroy');
       omise.customers.destroyCard(customerId, cardId, function(err, resp) {
-        expect(resp.object, 'card');
-        expect(resp.id, 'card_test_4z2owrdmvbygi7ah0fu');
+        if (err) done(err);
+        assert.equal(resp.object, 'card');
+        assert.equal(resp.id, 'card_test_4z2owrdmvbygi7ah0fu');
         resp.deleted.should.be.true;
-        done(err);
+        done();
       });
     });
   });

--- a/test/test_omise_charges.js
+++ b/test/test_omise_charges.js
@@ -1,8 +1,4 @@
-'use strict';
-const chai   = require('chai');
-const expect = chai.expect;
-const should = chai.should();
-
+const {expect, assert, should} = require('chai');
 const config = require('./config');
 const omise  = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -25,13 +21,14 @@ describe('Omise', function() {
         },
       };
       omise.tokens.create(cardDetails, function(err, resp) {
-        should.exist(resp.id);
+        if (err) done(err);
+        should().exist(resp.id);
         tokenId = resp.id;
         expect(tokenId).to.contains('tokn_test');
-        should.exist(resp.card.id);
+        should().exist(resp.card.id);
         const cardId = resp.card.id;
         expect(cardId).to.contains('card_test');
-        done(err);
+        done();
       });
     });
 
@@ -45,62 +42,67 @@ describe('Omise', function() {
         'card':        tokenId,
       };
       omise.charges.create(charge, function(err, resp) {
-        expect(resp.object, 'charge');
+        if (err) done(err);
         chargeId = resp.id;
+        assert.equal(resp.object, 'charge');
         expect(chargeId).to.match(/^chrg_test/);
         expect(resp.capture).be.false;
         expect(resp.paid).be.false;
-        done(err);
+        done();
       });
     });
 
     it('should be able to reverse a charge', function(done) {
       testHelper.setupMock('charges_reverse');
       omise.charges.reverse(chargeId, function(err, resp) {
-        expect(resp.object, 'charge');
-        const reversed = resp.reversed;
-        reversed.should.be.true;
-        done(err);
+        if (err) done(err);
+        assert.equal(resp.object, 'charge');
+        resp.reversed.should.be.true;
+        done();
       });
     });
 
     it('should be able to expire a charge', function(done) {
       testHelper.setupMock('charge_expire');
       omise.charges.expire(chargeId, function(err, resp) {
-        expect(resp.object, 'charge');
+        if (err) done(err);
+        assert.equal(resp.object, 'charge');
         expect(resp.expired).be.true;
-        done(err);
+        done();
       });
     });
 
     it('should be able to list charges', function(done) {
       testHelper.setupMock('charges_list');
       omise.charges.list(function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp).to.have.property('data');
         expect(resp.data).to.be.a('array');
-        done(err);
+        done();
       });
     });
 
     it('should be able to limit charges list', function(done) {
       testHelper.setupMock('charges_list_data');
       omise.charges.list({limit: 1}, function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp).to.have.property('data');
         expect(resp.data).to.be.a('array');
         resp.limit.should.equal(1);
-        done(err);
+        done();
       });
     });
 
     it('should be able to retrieve a charge', function(done) {
       testHelper.setupMock('charges_retrieve');
       omise.charges.retrieve(chargeId, function(err, resp) {
-        expect(resp.object, 'charge');
+        if (err) done(err);
+        assert.equal(resp.object, 'charge');
         expect(resp).to.have.property('amount');
         resp.amount.should.equal(100000);
-        done(err);
+        done();
       });
     });
 
@@ -108,21 +110,21 @@ describe('Omise', function() {
       testHelper.setupMock('charges_update');
       const data = {description: 'test description'};
       omise.charges.update(chargeId, data, function(err, resp) {
-        expect(resp.object, 'charge');
-        const chargeId = resp.id;
-        expect(chargeId).to.match(/^chrg_test/);
-        expect(resp.description, 'test description');
-        done(err);
+        if (err) done(err);
+        assert.equal(resp.object, 'charge');
+        assert.equal(resp.description, 'test description');
+        expect(resp.id).to.match(/^chrg_test/);
+        done();
       });
     });
 
     it('should be able to capture a charge', function(done) {
       testHelper.setupMock('charges_capture');
       omise.charges.capture(chargeId, function(err, resp) {
-        expect(resp.object, 'charge');
-        const paid = resp.paid;
-        paid.should.be.true;
-        done(err);
+        if (err) done(err);
+        assert.equal(resp.object, 'charge');
+        resp.paid.should.be.true;
+        done();
       });
     });
   });

--- a/test/test_omise_charges_schedules.js
+++ b/test/test_omise_charges_schedules.js
@@ -1,7 +1,4 @@
-'use strict';
-const chai = require('chai');
-const expect = chai.expect;
-
+const {expect, assert} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -30,36 +27,39 @@ describe('Omise', function() {
           'description': 'schedule charge id:1',
         },
       }, function(err, resp) {
-        expect(resp.object, 'schedule');
+        if (err) done(err);
+        assert.equal(resp.object, 'schedule');
         expect(resp).to.have.property('charge');
         expect(resp.charge).to.have.property('amount');
         resp.charge.amount.should.equal(amount);
-        done(err);
+        done();
       });
     });
 
     it('should be able to list all charge schedules', function(done) {
       testHelper.setupMock('charge_schedules_list');
       omise.charges.schedules(function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
+        assert.equal(resp.data[0].object, 'schedule');
         expect(resp.data).to.be.instanceof(Array);
-        expect(resp.data[0].object, 'schedule');
         expect(resp.data[0]).to.include.keys('charge');
         expect(resp.data[0].charge).not.be.null;
         resp.data[0].id.should.equal(chargeScheduleId);
         resp.data[0].charge.customer.should.equal(customerId);
-        done(err);
+        done();
       });
     });
 
     it('should be able to retrieve a charge schedule', function(done) {
       testHelper.setupMock('charge_schedules_retrieve');
       omise.schedules.retrieve(chargeScheduleId, function(err, resp) {
-        expect(resp.object, 'schedule');
+        if (err) done(err);
+        assert.equal(resp.object, 'schedule');
         expect(resp).to.have.property('charge');
         expect(resp.charge).to.have.property('amount');
         resp.charge.amount.should.equal(amount);
-        done(err);
+        done();
       });
     });
 
@@ -68,9 +68,10 @@ describe('Omise', function() {
       function(done) {
         testHelper.setupMock('customer_schedules_list');
         omise.customers.schedules(customerId, function(err, resp) {
-          expect(resp.object, 'list');
+          if (err) done(err);
+          assert.equal(resp.object, 'list');
+          assert.equal(resp.data[0].object, 'schedule');
           expect(resp.data).to.be.instanceof(Array);
-          expect(resp.data[0].object, 'schedule');
           expect(resp.data[0]).to.include.keys('charge');
           expect(resp.data[0].charge).not.be.null;
 
@@ -78,20 +79,21 @@ describe('Omise', function() {
           expect(resp.data[0].charge).to.have.property('customer');
           resp.data[0].charge.amount.should.equal(amount);
           resp.data[0].charge.customer.should.equal(customerId);
-          done(err);
+          done();
         });
       });
 
     it('should be able to destroy a charge schedule', function(done) {
       testHelper.setupMock('charge_schedules_destroy');
       omise.schedules.destroy(chargeScheduleId, function(err, resp) {
-        expect(resp.object, 'schedule');
+        if (err) done(err);
+        assert.equal(resp.object, 'schedule');
         expect(resp).to.have.property('charge');
         expect(resp).to.have.property('status');
         expect(resp.charge).to.have.property('amount');
         resp.charge.amount.should.equal(amount);
         resp.status.should.equal('deleted');
-        done(err);
+        done();
       });
     });
   });

--- a/test/test_omise_customers.js
+++ b/test/test_omise_customers.js
@@ -1,8 +1,4 @@
-'use strict';
-const chai   = require('chai');
-const expect = chai.expect;
-const should = chai.should();
-
+const {expect, assert, should} = require('chai');
 const config = require('./config');
 const omise  = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -25,13 +21,14 @@ describe('Omise', function() {
         },
       };
       omise.tokens.create(cardDetails, function(err, resp) {
-        should.exist(resp.id);
+        if (err) done(err);
+        should().exist(resp.id);
         tokenId = resp.id;
         expect(tokenId).to.contains('tokn_test');
-        should.exist(resp.card.id);
+        should().exist(resp.card.id);
         const cardId = resp.card.id;
         expect(cardId).to.contains('card_test');
-        done(err);
+        done();
       });
     });
 
@@ -43,13 +40,14 @@ describe('Omise', function() {
         card:        tokenId,
       };
       omise.customers.create(data, function(err, resp) {
+        if (err) done(err);
         customerId = resp.id;
         expect(customerId).to.contains('cust_test');
         const obj = resp.object;
         obj.should.equal('customer');
         const email = resp.email;
         email.should.equal('john.doe@example.com');
-        done(err);
+        done();
       });
     });
 
@@ -64,12 +62,12 @@ describe('Omise', function() {
           'customer':    customerId,
         };
         omise.charges.create(charge, function(err, resp) {
-          expect(resp.object, 'charge');
-          const chargeId = resp.id;
-          expect(chargeId).to.match(/^chrg_test/);
+          if (err) done(err);
+          assert.equal(resp.object, 'charge');
+          expect(resp.id).to.match(/^chrg_test/);
           expect(resp.capture).be.false;
           expect(resp.paid).be.false;
-          done(err);
+          done();
         });
       }
     );
@@ -89,10 +87,11 @@ describe('Omise', function() {
           },
         };
         omise.tokens.create(cardDetails, function(err, resp) {
-          should.exist(resp.id);
+          if (err) done(err);
+          should().exist(resp.id);
           tokenId = resp.id;
           expect(tokenId).to.contains('tokn_test');
-          should.exist(resp.card.id);
+          should().exist(resp.card.id);
           const cardId = resp.card.id;
           expect(cardId).to.contains('card_test');
           testHelper.setupMock('charges_create');
@@ -105,13 +104,14 @@ describe('Omise', function() {
             'card':        tokenId,
           };
           omise.charges.create(charge, function(err, resp) {
+            if (err) done(err);
             expect(err).to.equal(null, err !== null ? err.message : null);
-            expect(resp.object, 'charge');
+            assert.equal(resp.object, 'charge');
             const chargeId = resp.id;
             expect(chargeId).to.match(/^chrg_test/);
             expect(resp.capture).be.false;
             expect(resp.paid).be.false;
-            done(err);
+            done();
           });
         });
       }
@@ -120,20 +120,22 @@ describe('Omise', function() {
     it('should be able to list all customers', function(done) {
       testHelper.setupMock('customers_list');
       omise.customers.list(function(err, resp) {
-        expect(resp.object, 'customer');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp.data).to.be.instanceof(Array);
-        expect(resp.data[0].object, 'card');
-        done(err);
+        assert.equal(resp.data[0].object, 'customer');
+        done();
       });
     });
 
     it('should be able to retrieve an existing customer', function(done) {
       testHelper.setupMock('customer_retrieve');
       omise.customers.retrieve(customerId, function(err, resp) {
-        expect(resp.object, 'customer');
+        if (err) done(err);
+        assert.equal(resp.object, 'customer');
         expect(resp.id).to.match(/^cust_test/);
-        expect(resp.email, 'john.doe@example.com');
-        done(err);
+        assert.equal(resp.email, 'john.doe@example.com');
+        done();
       });
     });
 
@@ -141,18 +143,20 @@ describe('Omise', function() {
       testHelper.setupMock('customer_update');
       const data = {description: 'New description'};
       omise.customers.update(customerId, data, function(err, resp) {
-        expect(resp.object, 'customer');
-        expect(resp.description, 'New description');
-        done(err);
+        if (err) done(err);
+        assert.equal(resp.object, 'customer');
+        assert.equal(resp.description, 'New description');
+        done();
       });
     });
 
     it('should be able to destroy an existing customer', function(done) {
       testHelper.setupMock('customers_destroy');
       omise.customers.destroy(customerId, function(err, resp) {
-        expect(resp.object, 'customer');
+        if (err) done(err);
+        assert.equal(resp.object, 'customer');
         expect(resp.deleted).to.be.true;
-        done(err);
+        done();
       });
     });
   });

--- a/test/test_omise_disputes.js
+++ b/test/test_omise_disputes.js
@@ -1,6 +1,4 @@
-'use strict';
-const chai   = require('chai');
-const expect = chai.expect;
+const {expect, assert} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -10,9 +8,10 @@ describe('Omise', function() {
     it('should be able to list all disputes', function(done) {
       testHelper.setupMock('disputes_list');
       omise.disputes.list(function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp.data).to.be.instanceof(Array);
-        done(err);
+        done();
       });
     });
 
@@ -22,41 +21,46 @@ describe('Omise', function() {
       it('should be able to list open disputes', function(done) {
         testHelper.setupMock('disputes_list_open');
         omise.disputes.listOpen(function(err, resp) {
-          expect(resp.object, 'list');
+          if (err) done(err);
+          assert.equal(resp.object, 'list');
           expect(resp.data).to.be.instanceof(Array);
-          expect(resp.data[0].status, 'open');
-          done(err);
+          assert.equal(resp.data[0].status, 'open');
+          done();
         });
       });
 
       it('should be able to list closed disputes', function(done) {
         testHelper.setupMock('disputes_list_closed');
         omise.disputes.listClosed(function(err, resp) {
-          expect(resp.object, 'list');
+          if (err) done(err);
+          assert.equal(resp.object, 'list');
           expect(resp.data).to.be.instanceof(Array);
-          expect(resp.data[0].status, 'closed');
-          done(err);
+          assert.equal(resp.data[0].status, 'closed');
+          done();
         });
       });
 
       it('should be able to list pending disputes', function(done) {
         testHelper.setupMock('disputes_list_pending');
         omise.disputes.listPending(function(err, resp) {
-          expect(resp.object, 'list');
+          if (err) done(err);
+          assert.equal(resp.object, 'list');
           expect(resp.data).to.be.instanceof(Array);
-          expect(resp.data[0].status, 'pending');
-          done(err);
+          assert.equal(resp.data[0].status, 'pending');
+          done();
         });
       });
 
       it('should be able to retrieve a dispute', function(done) {
         testHelper.setupMock('disputes_list');
         omise.disputes.list(function(err, resp) {
+          if (err) done(err);
           testHelper.setupMock('disputes_retrieve');
           omise.disputes.retrieve(resp.data[0].id, function(err, resp) {
-            expect(resp.message, 'testing dispute');
+            if (err) done(err);
+            assert.equal(resp.message, 'testing dispute');
             expect(resp.charge).to.match(/^chrg_test/);
-            done(err);
+            done();
           });
         });
       });
@@ -68,9 +72,10 @@ describe('Omise', function() {
           testHelper.setupMock('disputes_update');
           omise.disputes.update(resp.data[0].id, updateData,
             function(err, resp) {
-              expect(resp.message, updateData.message);
+              if (err) done(err);
+              assert.equal(resp.message, updateData.message);
               expect(resp.charge).to.match(/^chrg_test/);
-              done(err);
+              done();
             });
         });
       });

--- a/test/test_omise_events.js
+++ b/test/test_omise_events.js
@@ -1,6 +1,4 @@
-const chai   = require('chai');
-const expect = chai.expect;
-
+const {expect, assert} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -10,11 +8,12 @@ describe('Omise', function() {
     it('should be able to list events', function(done) {
       testHelper.setupMock('events_list');
       omise.events.list(function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp).to.have.property('data');
         expect(resp.data).to.be.a('array');
-        expect(resp.data[0].object, 'event');
-        done(err);
+        assert.equal(resp.data[0].object, 'event');
+        done();
       });
     });
 
@@ -22,10 +21,11 @@ describe('Omise', function() {
       testHelper.setupMock('event_retrieve');
       omise.events.retrieve('evnt_test_52lfalk2p3ssnhwfoez',
         function(err, resp) {
-          expect(resp.object, 'event');
-          expect(resp.id, 'evnt_test_52lfalk2p3ssnhwfoez');
-          expect(resp.key, 'charge.create');
-          done(err);
+          if (err) done(err);
+          assert.equal(resp.object, 'event');
+          assert.equal(resp.id, 'evnt_test_52lfalk2p3ssnhwfoez');
+          assert.equal(resp.key, 'transfer.update');
+          done();
         }
       );
     });

--- a/test/test_omise_host.js
+++ b/test/test_omise_host.js
@@ -1,5 +1,4 @@
-const chai = require('chai');
-const expect = chai.expect;
+const {assert} = require('chai');
 const config = require('./config');
 const omise = require('../index');
 const testHelper = require('./testHelper');
@@ -17,17 +16,18 @@ describe('Omise', function() {
     it('Correct Host should be able to retrieve an account', function(done) {
       testHelper.setupMock('account_retrieve');
       omiseWithCorrectHost.account.retrieve(function(err, resp) {
-        expect(resp.object, 'account');
-        expect(resp.id, 'acct_123');
-        expect(resp.email, 'test@omise.co');
-        done(err);
+        if (err) done(err);
+        assert.equal(resp.object, 'account');
+        assert.equal(resp.id, 'acct_123');
+        assert.equal(resp.email, 'test@omise.co');
+        done();
       });
     });
 
     it('Wrong Host should return error', function(done) {
       testHelper.setupMock('account_retrieve');
       omiseWithWrongHost.account.retrieve(function(err, resp) {
-        expect(err.object, 'error');
+        assert.typeOf(err, 'Error');
         done();
       });
     });

--- a/test/test_omise_links.js
+++ b/test/test_omise_links.js
@@ -1,6 +1,4 @@
-'use strict';
-const chai   = require('chai');
-const expect = chai.expect;
+const {assert, expect} = require('chai');
 const config = require('./config');
 const omise  = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -17,9 +15,10 @@ describe('Omise', function() {
       };
       testHelper.setupMock('links_create');
       omise.links.create(link, function(err, resp) {
-        expect(resp.object, 'link');
-        expect(resp.amount, 19000);
-        expect(resp.used, false);
+        if (err) done(err);
+        assert.equal(resp.object, 'link');
+        assert.equal(resp.amount, 19000);
+        assert.equal(resp.used, false);
         done(err);
       });
     });
@@ -27,17 +26,18 @@ describe('Omise', function() {
     it('should be able to list all links', function(done) {
       testHelper.setupMock('links_list');
       omise.links.list(function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp.data).to.be.instanceof(Array);
         expect(resp.data.length).to.equal(2);
-        expect(resp.data[0].object, 'link');
+        assert.equal(resp.data[0].object, 'link');
         expect(resp.data[0]).to.include.keys('amount');
         expect(resp.data[0].amount).not.be.null;
         expect(resp.data[0]).to.include.keys('title');
         expect(resp.data[0]).to.include.keys('multiple');
         expect(resp.data[0]).to.include.keys('charges');
         expect(resp.data[0]).to.include.keys('payment_uri');
-        done(err);
+        done();
       });
     });
   });
@@ -45,11 +45,12 @@ describe('Omise', function() {
   it('should be able to retrieve the link', function(done) {
     testHelper.setupMock('links_retrieve');
     omise.links.retrieve('link_test_576mf2s2gwt0nmkmmf6', function(err, resp) {
-      expect(resp.id, 'link_test_576mf2s2gwt0nmkmmf6');
-      expect(resp.object, 'link');
+      if (err) done(err);
+      assert.equal(resp.id, 'link_test_576mf2s2gwt0nmkmmf6');
+      assert.equal(resp.object, 'link');
       expect(resp).to.include.keys('amount');
       expect(resp.amount).not.be.null;
-      done(err);
+      done();
     });
   });
 });

--- a/test/test_omise_recipients.js
+++ b/test/test_omise_recipients.js
@@ -1,6 +1,4 @@
-'use strict';
-const chai   = require('chai');
-const expect = chai.expect;
+const {assert, expect} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -22,32 +20,35 @@ describe('Omise', function() {
       };
       testHelper.setupMock('recipients_create');
       omise.recipients.create(recipient, function(err, resp) {
-        expect(resp.object, 'recipient');
-        expect(resp.type, 'individual');
-        expect(resp.type, 1273456789);
+        if (err) done(err);
+        assert.equal(resp.object, 'recipient');
+        assert.equal(resp.type, 'individual');
+        assert.equal(resp.tax_id, 1234567890);
         expect(resp).to.include.keys('bank_account');
-        expect(resp.bank_account.last_digits, 7890);
-        done(err);
+        assert.equal(resp.bank_account.last_digits, 7890);
+        done();
       });
     });
 
     it('should be able to list all recipients', function(done) {
       testHelper.setupMock('recipients_list');
       omise.recipients.list(function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp.data).to.be.instanceof(Array);
-        expect(resp.data[0].object, 'recipient');
+        assert.equal(resp.data[0].object, 'recipient');
         expect(resp.data[0]).to.include.keys('type');
         expect(resp.data[0].type).not.be.null;
         expect(resp.data[0]).to.include.keys('tax_id');
         expect(resp.data[0]).to.include.keys('bank_account');
-        done(err);
+        done();
       });
     });
 
     it('should be able to update the recipient', function(done) {
       testHelper.setupMock('recipients_list');
       omise.recipients.list(function(err, resp) {
+        if (err) done(err);
         const recipientId = resp.data[0].id;
         const updateData = {
           'name':   'Di Di',
@@ -56,10 +57,11 @@ describe('Omise', function() {
         };
         testHelper.setupMock('recipients_update');
         omise.recipients.update(recipientId, updateData, function(err, resp) {
-          expect(resp.name, updateData.name);
-          expect(resp.email, updateData.email);
-          expect(resp.tax_id, updateData.tax_id);
-          done(err);
+          if (err) done(err);
+          assert.equal(resp.name, updateData.name);
+          assert.equal(resp.email, updateData.email);
+          assert.equal(resp.tax_id, updateData.tax_id);
+          done();
         });
       });
     });
@@ -67,11 +69,13 @@ describe('Omise', function() {
     it('should be able to retrieve the recipient', function(done) {
       testHelper.setupMock('recipients_list');
       omise.recipients.list(function(err, resp) {
+        if (err) done(err);
         const recipientId = resp.data[0].id;
         testHelper.setupMock('recipients_retrieve');
         omise.recipients.retrieve(recipientId, function(err, resp) {
-          expect(resp.id, recipientId);
-          done(err);
+          if (err) done(err);
+          assert.equal(resp.id, recipientId);
+          done();
         });
       });
     });
@@ -79,19 +83,21 @@ describe('Omise', function() {
     it('should be able to destroy the recipient', function(done) {
       testHelper.setupMock('recipients_list');
       omise.recipients.list(function(err, resp) {
+        if (err) done(err);
         const recipients = resp.data;
         expect(resp.data).to.be.instanceof(Array);
         // atm, the first recipient is always a default, but cannot destroy
         expect(omise.recipients.destroy).instanceof(Function);
         if (recipients.length < 1) {
-          done(err);
+          done();
         }
         const recipientId = recipients[recipients.length - 1].id;
         testHelper.setupMock('recipients_destroy');
         omise.recipients.destroy(recipientId, function(err, resp) {
-          expect(resp.id, recipientId);
-          expect(resp.deleted, true);
-          done(err);
+          if (err) done(err);
+          assert.equal(resp.id, recipientId);
+          assert.equal(resp.deleted, true);
+          done();
         });
       });
     });

--- a/test/test_omise_refunds.js
+++ b/test/test_omise_refunds.js
@@ -1,7 +1,4 @@
-const chai   = require('chai');
-const expect = chai.expect;
-const should = chai.should();
-
+const {assert, expect, should} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -27,8 +24,9 @@ describe('Omise', function() {
       };
 
       omise.tokens.create(cardDetails, function(err, resp) {
+        if (err) done(err);
         tokenId = resp.id;
-        should.exist(resp.card.id);
+        should().exist(resp.card.id);
         testHelper.setupMock('charges_create');
         const charge = {
           'description': 'Charge for order 3947',
@@ -37,16 +35,18 @@ describe('Omise', function() {
           'card':        tokenId,
         };
         omise.charges.create(charge, function(err, resp) {
+          if (err) done(err);
           chargeId = resp.id;
           const amount = resp.amount;
           testHelper.setupMock('refunds_create');
           const data = {'amount': amount};
           omise.charges.createRefund(chargeId, data, function(err, resp) {
+            if (err) done(err);
             expect(resp.id).to.match(/^rfnd_test/);
-            expect(resp.object, 'refund');
-            expect(resp.amount, data['amount']);
-            expect(resp.currency, 'thb');
-            done(err);
+            assert.equal(resp.object, 'refund');
+            assert.equal(resp.amount, data['amount']);
+            assert.equal(resp.currency, 'thb');
+            done();
           });
         });
       });
@@ -55,22 +55,23 @@ describe('Omise', function() {
     it('should be able to list refunds', function(done) {
       testHelper.setupMock('refunds_list');
       omise.charges.listRefunds(chargeId, function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp.data).to.be.instanceof(Array);
-        expect(resp.data[0].object, 'refund');
+        assert.equal(resp.data[0].object, 'refund');
         refundId = resp.data[0].id;
-        done(err);
+        done();
       });
     });
 
     it('should be able to retrieve a refund', function(done) {
       testHelper.setupMock('refunds_retrieve');
       omise.charges.retrieveRefund(chargeId, refundId, function(err, resp) {
-        expect(resp.object, 'refund');
+        assert.equal(resp.object, 'refund');
         expect(resp.id).to.match(/^rfnd_test/);
         expect(resp.charge).to.match(/^chrg_test/);
         expect(resp.transaction).to.match(/^trxn_test/);
-        done(err);
+        done();
       });
     });
   });

--- a/test/test_omise_search.js
+++ b/test/test_omise_search.js
@@ -1,5 +1,4 @@
-const chai = require('chai');
-const expect = chai.expect;
+const {assert} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -10,9 +9,10 @@ describe('Omise', function() {
       testHelper.setupMock('search_transfer');
       const data = {'scope': 'transfer'};
       omise.search.list(data, function(err, resp) {
-        expect(resp.object, 'search');
-        expect(resp.scope, 'transfer');
-        done(err);
+        if (err) done(err);
+        assert.equal(resp.object, 'search');
+        assert.equal(resp.scope, 'transfer');
+        done();
       });
     });
   });

--- a/test/test_omise_source.js
+++ b/test/test_omise_source.js
@@ -1,9 +1,4 @@
-'use strict';
-
-const chai   = require('chai');
-const expect = chai.expect;
-const should = chai.should();
-
+const {assert, expect, should} = require('chai');
 const config = require('./config');
 const omise  = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -24,17 +19,19 @@ describe('Omise', function() {
 
     it('should be able to create a source', function(done) {
       omise.sources.create(sourceParameters, function(err, resp) {
+        if (err) done(err);
         sourceID = resp.id;
-        should.exist(sourceID);
+        should().exist(sourceID);
         expect(sourceID).to.contains(('src_'));
-        done(err);
+        done();
       });
     });
 
     it('should be able to retrieve a source', function(done) {
       testHelper.setupMock('sources_retrieve');
       omise.sources.retrieve(sourceID, function(err, resp) {
-        expect(resp.object, 'source');
+        if (err) done(err);
+        assert.equal(resp.object, 'source');
         expect(resp).to.have.property('amount');
         resp.amount.should.equal(500000);
         done(err);

--- a/test/test_omise_tokens.js
+++ b/test/test_omise_tokens.js
@@ -1,7 +1,4 @@
-const chai   = require('chai');
-const expect = chai.expect;
-const should = chai.should();
-
+const {expect, should} = require('chai');
 const config = require('./config');
 const omise  = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -23,22 +20,24 @@ describe('Omise', function() {
       };
       testHelper.setupMock('tokens_create');
       omise.tokens.create(cardDetails, function(err, resp) {
-        should.exist(resp.id);
+        if (err) done(err);
+        should().exist(resp.id);
         tokenId = resp.id;
         expect(tokenId).to.contains('tokn_test');
-        should.exist(resp.card.id);
+        should().exist(resp.card.id);
         const cardId = resp.card.id;
         expect(cardId).to.contains('card_test');
-        done(err);
+        done();
       });
     });
 
     it('should be able to retrieve a token', function(done) {
       testHelper.setupMock('token_retrieve');
       omise.tokens.retrieve(tokenId, function(err, resp) {
-        should.exist(resp.id);
+        if (err) done(err);
+        should().exist(resp.id);
         expect(resp.id).to.match(/^tokn_test/);
-        should.exist(resp.card.id);
+        should().exist(resp.card.id);
         const cardId = resp.card.id;
         expect(cardId).to.contains('card_test');
         done(err);

--- a/test/test_omise_transactions.js
+++ b/test/test_omise_transactions.js
@@ -1,5 +1,4 @@
-const chai   = require('chai');
-const expect = chai.expect;
+const {expect, assert} = require('chai');
 const config = require('./config');
 const omise  = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -10,20 +9,22 @@ describe('Omise', function() {
     it('should be able to list all transactions', function(done) {
       testHelper.setupMock('transactions_list');
       omise.transactions.list(function(err, resp) {
-        expect(resp.object, 'list');
-        expect(resp.data['0'].object, 'transaction');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
+        assert.equal(resp.data['0'].object, 'transaction');
         transactionId = resp.data['0'].id;
-        done(err);
+        done();
       });
     });
 
     it('should be able to retrieve a transaction', function(done) {
       testHelper.setupMock('transaction_retrieve');
       omise.transactions.retrieve(transactionId, function(err, resp) {
-        expect(resp.object, 'transaction');
+        if (err) done(err);
+        assert.equal(resp.object, 'transaction');
         expect(resp.id).to.match(/^trxn_test/);
-        expect(resp.amount, 96094);
-        done(err);
+        assert.equal(resp.amount, 96094);
+        done();
       });
     });
   });

--- a/test/test_omise_transfers.js
+++ b/test/test_omise_transfers.js
@@ -1,5 +1,4 @@
-const chai   = require('chai');
-const expect = chai.expect;
+const {expect, assert} = require('chai');
 const config = require('./config');
 const omise  = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -14,9 +13,10 @@ describe('Omise', function() {
       omise.transfers.create(data, function() {
         testHelper.setupMock('transfers_list');
         omise.transfers.list(function(err, resp) {
-          expect(resp.object, 'transfer');
+          if (err) done(err);
+          assert.equal(resp.object, 'list');
           transferId = resp.data[0].id;
-          done(err);
+          done();
         });
       });
     });
@@ -24,7 +24,8 @@ describe('Omise', function() {
     it('should be able to retrieve an existing transfer', function(done) {
       testHelper.setupMock('transfers_retrieve');
       omise.transfers.retrieve(transferId, function(err, resp) {
-        expect(resp.object, 'transfer');
+        if (err) done(err);
+        assert.equal(resp.object, 'transfer');
         expect(resp.amount).not.null;
         done();
       });
@@ -34,19 +35,21 @@ describe('Omise', function() {
       testHelper.setupMock('transfers_update');
       const data = {'amount': 5000};
       omise.transfers.update(transferId, data, function(err, resp) {
-        expect(resp.object, 'transfer');
+        if (err) done(err);
+        assert.equal(resp.object, 'transfer');
         const amount = resp.amount;
         amount.should.equal(5000);
-        done(err);
+        done();
       });
     });
 
     it('should be able to destroy an existing transfer', function(done) {
       testHelper.setupMock('transfers_destroy');
       omise.transfers.destroy(transferId, function(err, resp) {
-        expect(resp.object, 'transfer');
+        if (err) done(err);
+        assert.equal(resp.object, 'transfer');
         expect(resp.deleted).to.be.true;
-        done(err);
+        done();
       });
     });
   });

--- a/test/test_omise_transfers_schedules.js
+++ b/test/test_omise_transfers_schedules.js
@@ -1,7 +1,4 @@
-'use strict';
-const chai = require('chai');
-const expect = chai.expect;
-
+const {expect, assert} = require('chai');
 const config = require('./config');
 const omise = require('../index')(config);
 const testHelper = require('./testHelper');
@@ -29,25 +26,27 @@ describe('Omise', function() {
           'description': 'schedule transfer id:1',
         },
       }, function(err, resp) {
-        expect(resp.object, 'schedule');
+        if (err) done(err);
+        assert.equal(resp.object, 'schedule');
         expect(resp).to.have.property('transfer');
         expect(resp.transfer).to.have.property('amount');
         resp.transfer.amount.should.equal(amount);
-        done(err);
+        done();
       });
     });
 
     it('should be able to list all transfer schedules', function(done) {
       testHelper.setupMock('transfers_schedules_list');
       omise.transfers.schedules(function(err, resp) {
-        expect(resp.object, 'list');
+        if (err) done(err);
+        assert.equal(resp.object, 'list');
         expect(resp.data).to.be.instanceof(Array);
-        expect(resp.data[0].object, 'schedule');
+        assert.equal(resp.data[0].object, 'schedule');
         expect(resp.data[0]).include.keys('transfer');
         expect(resp.data[0].transfer).not.be.null;
         resp.data[0].id.should.equal(transferScheduleId);
         resp.data[0].transfer.recipient.should.equal(recipientId);
-        done(err);
+        done();
       });
     });
 
@@ -55,38 +54,41 @@ describe('Omise', function() {
       function(done) {
         testHelper.setupMock('recipients_schedules_list');
         omise.recipients.schedules(recipientId, function(err, resp) {
-          expect(resp.object, 'list');
+          if (err) done(err);
+          assert.equal(resp.object, 'list');
           expect(resp.data).to.be.instanceof(Array);
-          expect(resp.data[0].object, 'schedule');
+          assert.deepEqual(resp.data[0].object, 'schedule');
           expect(resp.data[0]).include.keys('transfer');
           expect(resp.data[0].transfer).not.be.null;
           resp.data[0].id.should.equal(transferScheduleId);
           resp.data[0].transfer.recipient.should.equal(recipientId);
-          done(err);
+          done();
         });
       });
 
     it('should be able to retrieve a transfer schedule', function(done) {
       testHelper.setupMock('transfers_schedules_retrieve');
       omise.schedules.retrieve(transferScheduleId, function(err, resp) {
-        expect(resp.object, 'schedule');
+        if (err) done(err);
+        assert.equal(resp.object, 'schedule');
         expect(resp).to.have.property('transfer');
         expect(resp.transfer).to.have.property('amount');
         resp.transfer.amount.should.equal(amount);
-        done(err);
+        done();
       });
     });
 
     it('should be able to destroy a transfer schedule', function(done) {
       testHelper.setupMock('transfers_schedules_destroy');
       omise.schedules.destroy(transferScheduleId, function(err, resp) {
-        expect(resp.object, 'schedule');
+        if (err) done(err);
+        assert.equal(resp.object, 'schedule');
         expect(resp).to.have.property('transfer');
         expect(resp).to.have.property('status');
         expect(resp.transfer).to.have.property('amount');
         resp.transfer.amount.should.equal(amount);
         resp.status.should.equal('deleted');
-        done(err);
+        done();
       });
     });
   });


### PR DESCRIPTION
Support backward compatibility with warning message for handling promise.

<img width="515" alt="Screenshot 2023-03-16 at 2 44 30 PM" src="https://user-images.githubusercontent.com/108650842/225548658-44d03ccc-159f-41d9-b411-9cbb62151196.png">


Update invalid test cases
     - `expect(foo, "bar")` always return true and the correct way is `assert.equal(foo, "bar")`
     - `if (err) done(err);` done function must call if there is any error. Otherwise the unit test asserting will be mark as error and not showing the failed result properly.
    
 
<img width="515" alt="Screenshot 2023-03-16 at 2 43 39 PM" src="https://user-images.githubusercontent.com/108650842/225548470-3a954ea9-1e0c-4ec6-b0b7-da489b738ef4.png">

 
