### PR TITLE
Bug fixed for NEXTJS issue

### DIFF
--- a/lib/apiResources.js
+++ b/lib/apiResources.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 let omiseConfig;
 
 function resourceName(name) {
-  return require(['./resources/', name].join(''))(omiseConfig);
+  return require('./resources/' + name)(omiseConfig);
 }
 
 function resourcePath(name) {

--- a/lib/apiResources.js
+++ b/lib/apiResources.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 let omiseConfig;
 
 function resourceName(name) {
-  return require('./resources/' + name)(omiseConfig);
+  return require(`./resources/${name}`)(omiseConfig);
 }
 
 function resourcePath(name) {


### PR DESCRIPTION
## Purpose

Bug fixed for NEXTJS issue

Similar fix of https://github.com/omise/omise-node/pull/166

## Description

- Replace array `[].join()` with normal `+` sign to join the string

## Quality assurance

- Tested on `Next.js 12` and `Next.js 13`.
- Node version : v18.14.0
