### PR TITLE
Fix Sonarcloud report path

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,9 +23,6 @@ jobs:
       - run: npm run lint
       - run: npm run test:coverage
 
-      - name: Fix Code Coverage Paths
-        run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage/lcov.info
-
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,11 +17,14 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: npm install
       - run: npx tsc --noEmit --lib es2015 types/index.d.ts
       - run: npm run build --if-present
       - run: npm run lint
       - run: npm run test:coverage
+
+      - name: Fix Code Coverage Paths
+        run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' coverage/lcov.info
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - run: npm ci
       - run: npx tsc --noEmit --lib es2015 types/index.d.ts
       - run: npm run build --if-present
       - run: npm run lint

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=omise_omise-node
 sonar.organization=omise
-sonar.coverage.reportPaths=./coverage/lcov.info
+sonar.javascript.coverage.reportPaths=./coverage/lcov.info
 
 sonar.exclusions=/test/**, /types/**, /examples/**
 sonar.coverage.exclusions=/test/**, /types/**, /examples/**

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=omise_omise-node
 sonar.organization=omise
-sonar.javascript.coverage.reportPaths=./coverage/lcov.info
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
 
 sonar.exclusions=/test/**, /types/**, /examples/**
 sonar.coverage.exclusions=/test/**, /types/**, /examples/**


### PR DESCRIPTION
## Purpose

Fixed Sonarcloud report path in sonar properties file

Related PR - #201 

Will be `93.3%` Estimated after merge

<img width="443" alt="Screenshot 2023-07-27 at 10 41 57 AM" src="https://github.com/omise/omise-node/assets/108650842/96d477d4-3da8-46ff-b522-47de844af539"><br>


Github action Logs

```
INFO: Sensor JavaScript/TypeScript Coverage [javascript]
INFO: Analysing [/github/workspace/./coverage/lcov.info]
INFO: Sensor JavaScript/TypeScript Coverage [javascript] (done) | time=17ms
```
